### PR TITLE
substract 15min from time  - card2_apexcharts_analysis.yaml

### DIFF
--- a/examples/card2_apexcharts_analysis.yaml
+++ b/examples/card2_apexcharts_analysis.yaml
@@ -72,6 +72,7 @@
       yaxis_id: price
       type: line
       curve: smooth
+      time_delta: "-15min"
       stroke_width: 5
       extend_to: false
       color_threshold:
@@ -97,6 +98,7 @@
       yaxis_id: price
       type: line
       curve: smooth
+      time_delta: "-15min"
       stroke_width: 5
       opacity: 0.7
       extend_to: false


### PR DESCRIPTION
Propozycja dla data_generator'a dla apex-charts
-----------
  return entity.attributes.prices.map((entry) => {
    const date = new Date(entry.dtime);
    date.setMinutes(date.getMinutes() - 15);
    return [date.getTime(), parseFloat(entry.rce_pln)];
  });
______
lub poprzez dodanie "time_delta: -15min" do danej serii - w sumie prostsze.

Po co? a dlatego, że czasy przekazywane przez to API są mylne, bo czas 'dtime' pokazuje koniec czasu danego okna, a nie jego początek, a w HA korzystamy z danych które mówią kiedy jakaś dana ma wartość, czyli początek. To powoduje, że obecny przykład sugeruje że cena zmienia się XX:15 a nie XX:00 jak jest faktycznie.