### PR TITLE
fix: treat 24:00 as end-of-day

### DIFF
--- a/custom_components/rce_pse/time_window.py
+++ b/custom_components/rce_pse/time_window.py
@@ -65,11 +65,13 @@ def is_valid_quarter_step(hhmm: str) -> bool:
 
 
 def is_search_end_end_of_day(hhmm: str) -> bool:
-    return normalize_hhmm(hhmm) == "00:00"
+    return normalize_hhmm(hhmm) in ("00:00", "24:00")
 
 
 def parse_hhmm_to_time(hhmm: str) -> time:
     h, m = map(int, normalize_hhmm(hhmm).split(":"))
+    if h >= 24:
+        return time(hour=23, minute=59)
     return time(hour=h, minute=m)
 
 

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -5,6 +5,7 @@ from custom_components.rce_pse.time_window import (
     is_search_end_end_of_day,
     is_valid_quarter_step,
     normalize_hhmm,
+    parse_hhmm_to_time,
     parse_pse_dtime,
     period_bounds_for_record,
     period_overlaps_search,
@@ -42,6 +43,11 @@ def test_search_end_eod():
     assert ex == datetime(2024, 1, 2, 0, 0, 0)
 
 
+def test_search_end_eod_2400():
+    ex = search_window_exclusive_end("2024-01-01", "24:00")
+    assert ex == datetime(2024, 1, 2, 0, 0, 0)
+
+
 def test_search_end_fixed():
     ex = search_window_exclusive_end("2024-01-01", "10:00")
     assert ex == datetime(2024, 1, 1, 10, 0, 0)
@@ -65,3 +71,9 @@ def test_is_now_in_window_end_exclusive():
 def test_is_search_end_end_of_day():
     assert is_search_end_end_of_day("00:00") is True
     assert is_search_end_end_of_day("0:00") is True
+    assert is_search_end_end_of_day("24:00") is True
+    assert is_search_end_end_of_day("24:00:00") is True
+
+
+def test_parse_hhmm_to_time_2400():
+    assert parse_hhmm_to_time("24:00") == datetime(2000, 1, 1, 23, 59).time()


### PR DESCRIPTION
Accept 24:00 as an end-of-day search bound and avoid creating invalid time(24, 0). Add regression tests covering 24:00 handling.

close #75 #80 