### PR TITLE
fix: correct entity name in English example dashboard

### DIFF
--- a/examples/dashboard-lovelace-EN.yaml
+++ b/examples/dashboard-lovelace-EN.yaml
@@ -92,7 +92,7 @@ views:
                   extremas: true
                   in_header: after_now
                   legend_value: false
-              - entity: sensor.rce_pse_tomorrow_price
+              - entity: sensor.rce_pse_price_tomorrow
                 attribute: prices
                 name: Price tomorrow
                 yaxis_id: price
@@ -362,10 +362,10 @@ views:
           - type: vertical-stack
             visibility:
               - condition: state
-                entity: sensor.rce_pse_tomorrow_price
+                entity: sensor.rce_pse_price_tomorrow
                 state_not: unavailable
               - condition: state
-                entity: sensor.rce_pse_tomorrow_price
+                entity: sensor.rce_pse_price_tomorrow
                 state_not: unknown
             cards:
               - type: markdown


### PR DESCRIPTION
## Podsumowanie

Poprawienie błędów nazw encji w angielskim pliku przykładowego dashboard.

## Problem

Plik anglojęzycznego przykładu (`examples/dashboard-lovelace-EN.yaml`) zawiera nieprawidłowe nazwy encji w kilku miejscach.

**Przyczyna:**
Home Assistant z `has_entity_name=True` generuje entity_id w kolejności `{device}_{descriptor}_{day}`, ale przykład YAML używa nieprawidłowej kolejności słów i przestarzałych/błędnych nazw.

**Wynik:**
Wszystkie dotknięte encje teraz mają prawidłowe nazwy zgodne z integracją.